### PR TITLE
Update Umami analytics script URL

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const { title } = Astro.props;
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
-    <script defer src="https://analytics.us.umami.is/script.js" data-website-id={import.meta.env.UMAMI_ID}></script>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id={import.meta.env.UMAMI_ID}></script>
     <PostHog />
   </head>
   <body


### PR DESCRIPTION
Switched the Umami script source from the US domain to the cloud domain for improved reliability and consistency. This ensures the analytics script is loaded from the preferred source.